### PR TITLE
docs: switch logout link to POST form in dj4e_mkt1.md example

### DIFF
--- a/assn/dj4e_mkt1.md
+++ b/assn/dj4e_mkt1.md
@@ -173,7 +173,13 @@ to be:
                 <img style="width: 25px;" src="{{ user|gravatar:60 }}"/><b class="caret"></b>
             </a>
             <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="rightnavDropdown">
-                <li><a class="dropdown-item" href="{% url 'logout' %}?next={% url 'mkt:all' %}">Logout</a></li>
+                <li>
+                    <form action="{% url 'logout' %}" method="post" class="d-inline">
+                        {% csrf_token %}
+                        <input type="hidden" name="next" value="{% url 'mkt:all' %}">
+                        <button class="dropdown-item btn btn-link" type="submit">Logout</button>
+                    </form>
+                </li>
             </ul>
            </li>
            {% else %}


### PR DESCRIPTION
Django 4.1+ deprecated logging out via GET method, and Django 5.x removed it entirely. Copying & pasting the old logout anchor tag for this assignment (in the `base_menu.html` template example) leaves students on a blank page instead of logging out.

This fix replaces the anchor tag with the mini-form pattern recommended by the Django docs. This is also used in the live marketplace example site (`https://market.dj4e.com/m1/`).

* adds <form> + {% csrf_token %} + hidden `next` input.
* uses same CSS classes for styling as working `https://market.dj4e.com` logout form.

File: assn/dj4e_mkt1.md