### PR TITLE
fix: point 'Marketplace + Comments (3)' lesson to the correct assignment spec

### DIFF
--- a/lessons.json
+++ b/lessons.json
@@ -1963,7 +1963,7 @@
     "anchor": "dj4e_mkt3",
     "icon" : "fa-comment",
     "description": "We add comments to our marketplace application.",
-    "assignment" : "{apphome}/assn/dj4e_mkt4.md",
+    "assignment" : "{apphome}/assn/dj4e_mkt3.md",
     "discussions" : [
         {
         "title" : "Marketplace + Comments (3)",


### PR DESCRIPTION
The lessons.json entry for "Marketplace + Comments (3)" referenced `assn/dj4e_mkt4.md`, which belongs to the next lesson. This commit changes the assignment field to `{apphome}/assn/dj4e_mkt3.md` so the "Assignment Specification" link on the lesson page loads the intended document. No other files were modified.