### PR TITLE
docs(mkt3) - use correct `mkt` namespace in CommentDeleteView url path

### DIFF
--- a/assn/dj4e_mkt3.md
+++ b/assn/dj4e_mkt3.md
@@ -78,7 +78,7 @@ routes from `forums/urls.py`.  Make sure to use the same URL patterns as shown h
         path('ad/<int:pk>/comment',
             views.CommentCreateView.as_view(), name='ad_comment_create'),
         path('comment/<int:pk>/delete',
-            views.CommentDeleteView.as_view(success_url=reverse_lazy('ads:all')), name='ad_comment_delete'),
+            views.CommentDeleteView.as_view(success_url=reverse_lazy('mkt:all')), name='ad_comment_delete'),
     ]
 
 (7) Adapt the comment related views from `forums/views.py` and put them into your `views.py`.


### PR DESCRIPTION
The 'MarketPlace with Comments (3)' assignment specification (`assn/dj43_mkt3.md`) still shows `reverse_lazy('ads:all')` for the CommendDeleteView url path, a leftover from the prior Ads assignment. This causes a `NoReverseMatch` when students copy the code verbatim and don't use the `get_success_url` method in the CommentDeleteView (the `get_success_url` method overrides `reverse_lazy` in the urls.py path, which might be why this typo wasn't discovered). Switched to `mkt:all` to match the rest of the Marketplace assignments.